### PR TITLE
change config host name - remove www

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ email: dilini.javacodehouse@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   Java code house is a resource for developers to learn and share emerging technologies in the software development field.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://www.javacodehouse.com" # the base hostname & protocol for your site
+url: "https://javacodehouse.com" # the base hostname & protocol for your site
 twitter_username: sewdil
 github_username:  DiliniRajapaksha
 twitter:


### PR DESCRIPTION
Removed www from the hostname in _config to support imported Disqus comments in Hyvor.